### PR TITLE
A first improvement of the Swedish translation

### DIFF
--- a/_src/sv/index.md
+++ b/_src/sv/index.md
@@ -2,11 +2,19 @@
 title: Free Ola Bini
 layout: base.njk
 ---
-Personer som arbetar för fri programvara och integritet bör inte kriminaliseras
+Arbete med fri programvara och integritet får inte kriminaliseras
 
-Det finns inget kriminellt om vill ha integritet.
+Att bry sig om personlig integritet är inte olagligt
 
-Ola Bini, @olabini, en världsberömd siffra inom fri programvara och försvarare för digitala rättigheter och integritet, greps på flygplatsen i Quito, Ecuador klockan 3.20.20. lokal tid den 11 april 2019. Såvitt det är känt finns det inga avgifter mot honom. Hans advokater fick inte träffas honom hela dagen och fick endast tillgång till honom efter att han fängslats i 17 timmar. Klockan 6 de fick höra att de skulle överföra honom till flaggante Delicto-enheten (Unidad de Flagrancia de la Fiscalía) hos advokatkontoret i centrala norra Quito för att ge uttalanden i en utredning av provinsiella advokatbyråns kontor i Pichincha.
+Ola Bini, @olabini, välkänd inom fri programvarurörelsen, digitala
+rättigheter och integritetsfrågor, blev den 11 april 2019 kl 15:20
+lokal tid gripen på flygplatsen i Quito, Ecuador. Såvitt det är känt
+finns inga formella anklagelser mot honom. Hans advokater fick inte
+möjlighet att träffa honom på hela dagen och lyckades etablera kontakt
+först efter 17 timmar i fångenskap. Klockan sex på kvällen fick de
+uppgifter om att han skulle överföras till Flagrante Delicto, en enhet
+under riksåklagaren, för att höras i en utredning hos
+distriktsåklagaren i Pinchincha.
 
 {% set posts = collections.sv %}
 {% include "posts.njk" %}

--- a/_src/sv/ola-bini-arrest.md
+++ b/_src/sv/ola-bini-arrest.md
@@ -7,17 +7,41 @@ date: 2019-04-12
 image: /img/ola.jpg
 title: Ola Bini Arresterad I Ecuador
 ---
-Personer som arbetar för fri programvara och integritet bör inte kriminaliseras
 
-Det finns inget kriminellt om vill ha integritet.
+Arbete med fri programvara och integritet får inte kriminaliseras
 
-Ola Bini, @olabini, en världsberömd siffra inom fri programvara och försvarare för digitala rättigheter och integritet, greps på flygplatsen i Quito, Ecuador klockan 3.20.20. lokal tid den 11 april 2019. Såvitt det är känt finns det inga avgifter mot honom. Hans advokater fick inte träffas honom hela dagen och fick endast tillgång till honom efter att han fängslats i 17 timmar. Klockan 6 de fick höra att de skulle överföra honom till flaggante Delicto-enheten (Unidad de Flagrancia de la Fiscalía) hos advokatkontoret i centrala norra Quito för att ge uttalanden i en utredning av provinsiella advokatbyråns kontor i Pichincha.
+Att bry sig om personlig integritet är inte olagligt
 
-Bini, en svensk medborgare som bor i Ecuador, talar inte flytande spanska och kräver tolk att uttala sig. Han har hållits olagligt utan kända anklagelser och utan att underrätta myndigheterna i sitt land (Sverige) om sitt frihetsberövande enligt internationella protokoll.
+Ola Bini, @olabini, välkänd inom fri programvarurörelsen, digitala
+rättigheter och integritetsfrågor, blev den 11 april 2019 kl 15:20
+lokal tid gripen på flygplatsen i Quito, Ecuador. Såvitt det är känt
+finns inga formella anklagelser mot honom. Hans advokater fick inte
+möjlighet att träffa honom på hela dagen och lyckades etablera kontakt
+först efter 17 timmar i fångenskap. Klockan sex på kvällen fick de
+uppgifter om att han skulle överföras till Flagrante Delicto, en enhet
+under riksåklagaren, för att höras i en utredning hos
+distriktsåklagaren i Pinchincha.
 
-Han är teknisk direktör för Center for Digital Autonomy och hade på sitt Twitter-konto bokat att han skulle resa till Japan för en kampsportkurs, en resa planerad för mer än en månad sedan. Han såg kommentarer från Ecuadors inrikesminister och tweeted: "María Paula Romo, Ecuador Inrikesminister, denna morgon höll en presskonferens, hävdar att det finns ryska hackare i Ecuador, och att det finns en person som deltar i WikiLeaks som bor i Ecuador sedan flera år. "(Https://twitter.com/olabini/status/1116341908371062794)
+Bini, svensk medborgare bosatt i Ecuador, talar inte flytande spanska
+och är i behov av tolk för att kunna yttra sig i rättssaker. Han har
+olagligt hållits frihetsberövad på lösa gruner och utan att
+myndigheterna i hans land (Sverige) har underrättats i enlighet med
+internationell rätt.
 
-Bini har varit programansvarig hela sitt liv, har börjat programmera som ett 8-årigt barn och skapat två programmeringsspråk. Han är länge fri programvara och integritet och öppenhetsaktivist. I 2010 betygsatte Computerworld från Sverige Ola Bini som den 6: e topputvecklaren i landet.
+Han är teknisk chef för Center for Digital Autonomy och hade på sitt
+twitter-konto tidigare meddelat att han skulle resa till Japan på en
+kampsportkurs, en resa planerad sedan mer än en månad tillbaka. Som en
+kommentarer till ett uttalande av Ecuadors inrikesminister twittrade
+han: "María Paula Romo, Ecuadors inrikesminister, höll i morse en
+presskonferens där hon hävdar att det finns ryska hackare i Ecuador
+och att det även finns en person från WikiLeaks bosatt i Ecuador sedan
+flera år." (https://twitter.com/olabini/status/1116341908371062794)
+
+Bini har varit mjukvaruutvecklare i hela sitt liv sedan han började
+programmera som åttaåring och har skapat två programmeringsspråk. Han
+är mångårig aktivist och förespråkare för fri programvara,
+privatlivsskydd och transparens. ComputerSweden rankade 2010 Ola Bini
+som Sveriges sjätte främsta utvecklare.
 
 Han har bidragit till:
 


### PR DESCRIPTION
A few notes on the translation. I've translated:

- "Attorney General" into "riksåklagaren", which in Sweden is "the
  highest-ranked prosecutor in the country
  (https://en.wikipedia.org/wiki/Prosecutor-General_of_Sweden), and
  "provincial Attorney General" into "distriktsåklagare" which
  translates to English into "district attorney".

- "to make any statement" into "för att kunna yttra sig i rättssaker"
  which translates back into English as "to be able to make any
  statement in criminal matters".

- "known charges" into "på lösa grunder" which means approximately "on
  vague accusations". Perhaps "formell misstanke om brott" ("formal
  suspicion of a crime") could be used but I don't know the exact
  facts.

- "privacy" into two different words in two different
  places. "defender of [...] privacy" turned into "integritetsfrågor"
  (roughly "privacy matters") while "privacy [...] activist" turned
  into "aktivist och förespråkare för [...] privatlivsskydd" ("privacy
  activist and advocate").

A technical detail:

- I've broken the long lines into shorter lines because
  convenience. LMK if that is problematic in any way.